### PR TITLE
Storage Account Access & ServiceBus IP Rules

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -30,3 +30,9 @@ resource "azurerm_role_assignment" "service_bus_role_assignment" {
   scope                = azurerm_servicebus_queue.state_change_queue.id
   role_definition_name = "Azure Service Bus Data Receiver"
 }
+
+resource "azurerm_role_assignment" "enrichment_storage_account_assignment" {
+  principal_id         = azurerm_user_assigned_identity.app_identity.principal_id
+  scope                = data.azurerm_storage_account.enrichment_storage_account.id
+  role_definition_name = "Storage Blob Data Contributor"
+}

--- a/service_bus.tf
+++ b/service_bus.tf
@@ -1,14 +1,15 @@
 resource "azurerm_servicebus_namespace" "state_change_bus" {
-  location                      = var.location
-  name                          = var.service_bus_name
-  resource_group_name           = var.resource_group_name
-  sku                           = "Standard"
-  public_network_access_enabled = false
-  local_auth_enabled            = false
-  minimum_tls_version           = "1.2"
+  location            = var.location
+  name                = var.service_bus_name
+  resource_group_name = var.resource_group_name
+  sku                 = "Standard"
+  local_auth_enabled  = false
+  minimum_tls_version = "1.2"
 
   network_rule_set {
-    trusted_services_allowed = true
+    ip_rules = [
+      azurerm_container_app_environment.enrichment_app_env.static_ip_address
+    ]
   }
 
   tags = var.tags


### PR DESCRIPTION
# Description

IAM assignment to grant access to the container app identity to the storage account didn't make it into the re-org. Also updated the service bus to only allow traffic from the container app environment

## Type of change

Please delete options that are not relevant.

- [X] Bug Fix
- [ ] New Feature
- [ ] This change requires a documentation update

# How Has This Been Tested?

Tested end to end with this branch
