### PR TITLE
Adding nightly and PR trivy scans

### DIFF
--- a/.github/workflows/scan:trivy.yml
+++ b/.github/workflows/scan:trivy.yml
@@ -1,0 +1,22 @@
+name: Trivy Terraform Scan
+
+on:
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '0 3 * * *'          # Nightly at 03:00 UTC
+  workflow_dispatch:
+
+jobs:
+  trivy:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Trivy scan
+        uses: corelight/shared-actions/trivy-terraform-scan@main 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -11,3 +11,8 @@ tasks:
     desc: Check if the input is formatted
     cmds:
       - terraform fmt -recursive -check -diff .
+
+  trivy:scan:
+    desc: Scan Terraform files with Trivy
+    cmds:
+      - trivy fs --config scripts/trivy/trivy.yml .

--- a/scripts/trivy/.trivyignore.yml
+++ b/scripts/trivy/.trivyignore.yml
@@ -1,0 +1,1 @@
+misconfigurations:

--- a/scripts/trivy/trivy.yml
+++ b/scripts/trivy/trivy.yml
@@ -1,0 +1,19 @@
+scan:
+  security-checks:
+    - secret
+    - config
+
+ignorefile: scripts/trivy/.trivyignore.yml
+
+severity:
+  - HIGH
+  - CRITICAL
+
+misconfiguration:
+  scanners:
+    - terraform
+  config:
+    terraform:
+      file_patterns:
+        - "**/*.tf"
+  ignore_unfixed: true


### PR DESCRIPTION
# Automated Trivy Security Scans

This PR adds automated Trivy scans to every pull request targeting main and sets up a nightly job that runs the same scan directly against the main branch.

---

##  Key Changes

| Workflow | Frequency | Behaviour |
|----------|-----------|-----------|
| **Pull Request** | Every PR to **`main`** | Fails if any **`HIGH`** or **`CRITICAL`** vulnerabilities, or secrets are detected. |
| **Nightly (`main`)** | Daily ‑ 03:00 UTC | Runs on **`main`**; when the scan fails on **`HIGH`** or **`CRITICAL`** findings, the workflow opens  or re‑uses  a GitHub issue.<br>Example: [Issue #13](https://github.com/corelight/terraform-aws-sensor/issues/13). |

---

## Type of Change
**New feature** – adds preventive security gates and continuous monitoring.

---

## Validation & Testing

### Pull‑Request Pipeline
- Tested with branches containing known **`HIGH`/`CRITICAL`** findings → workflow **failed** as expected.  
- Tested with a clean branch → workflow **passed**.

### Nightly Workflow
- Temporarily removed branch/schedule guard to trigger issue‑creation logic.  
- Confirmed:
  - A single issue is opened on first failure.
  - Subsequent failures detect the open issue and do **not** create duplicates.